### PR TITLE
Add multiplayer option

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import { Routes, Route, Link } from 'react-router-dom';
 import Swipe from './Swipe';
 import Match from './Match';
 import AddRecipe from './AddRecipe';
+import Multiplayer from './Multiplayer';
 import { RecipeProvider } from './RecipeContext';
 
 export default function App() {
@@ -13,6 +14,7 @@ export default function App() {
         <nav className="mt-2">
           <Link className="underline mr-4" to="/">Home</Link>
           <Link className="underline mr-4" to="/swipe">Swipe</Link>
+          <Link className="underline mr-4" to="/multiplayer">Multiplayer</Link>
           <Link className="underline" to="/add">Add Recipe</Link>
         </nav>
       </header>
@@ -22,6 +24,7 @@ export default function App() {
           <Route path="/swipe" element={<Swipe />} />
           <Route path="/match" element={<Match />} />
           <Route path="/add" element={<AddRecipe />} />
+          <Route path="/multiplayer" element={<Multiplayer />} />
         </Routes>
       </main>
     </div>
@@ -32,10 +35,21 @@ export default function App() {
 function Home() {
   return (
     <div className="p-4 text-center">
-      <h2 className="text-xl mb-4">Start swiping with your partner</h2>
-      <Link to="/swipe" className="bg-pink-500 text-white px-4 py-2 rounded">
-        Start
-      </Link>
+      <h2 className="text-xl mb-4">Choose your mode</h2>
+      <div className="space-x-4">
+        <Link
+          to="/swipe"
+          className="bg-pink-500 text-white px-4 py-2 rounded inline-block"
+        >
+          Swipe Solo
+        </Link>
+        <Link
+          to="/multiplayer"
+          className="bg-pink-500 text-white px-4 py-2 rounded inline-block"
+        >
+          Multiplayer
+        </Link>
+      </div>
     </div>
   );
 }

--- a/src/Multiplayer.jsx
+++ b/src/Multiplayer.jsx
@@ -1,0 +1,11 @@
+import { Link } from 'react-router-dom';
+
+export default function Multiplayer() {
+  return (
+    <div className="p-4 text-center">
+      <h2 className="text-xl font-bold mb-4">Multiplayer Session</h2>
+      <p className="mb-4">Here you can create or join a multiplayer session. This is a placeholder for future functionality.</p>
+      <Link to="/" className="underline">Back to Home</Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- allow navigation to multiplayer session
- show choice between swipe solo or multiplayer on the homepage
- add new placeholder page for multiplayer sessions

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857b530a32c8328b4a7bbccbee2a019