### PR TITLE
Add rating flow for solo swipe

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import { Routes, Route, Link } from 'react-router-dom';
 import Swipe from './Swipe';
 import Match from './Match';
+import RateLikes from './RateLikes';
 import AddRecipe from './AddRecipe';
 import Multiplayer from './Multiplayer';
 import { RecipeProvider } from './RecipeContext';
@@ -22,6 +23,7 @@ export default function App() {
         <Routes>
           <Route index element={<Home />} />
           <Route path="/swipe" element={<Swipe />} />
+          <Route path="/rate" element={<RateLikes />} />
           <Route path="/match" element={<Match />} />
           <Route path="/add" element={<AddRecipe />} />
           <Route path="/multiplayer" element={<Multiplayer />} />

--- a/src/RateLikes.jsx
+++ b/src/RateLikes.jsx
@@ -1,0 +1,53 @@
+import { useLocation, Link } from 'react-router-dom';
+import { useState } from 'react';
+
+export default function RateLikes() {
+  const location = useLocation();
+  const likedRecipes = location.state?.likedRecipes || [];
+  const [ratings, setRatings] = useState(likedRecipes.map(() => 0));
+
+  const handleChange = (index, value) => {
+    setRatings((prev) => prev.map((r, i) => (i === index ? Number(value) : r)));
+  };
+
+  if (likedRecipes.length === 0) {
+    return (
+      <div className="p-4 text-center">
+        <h2 className="text-xl font-bold mb-4">No likes this session</h2>
+        <Link to="/" className="underline">Back to Home</Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4">
+      <h2 className="text-xl font-bold mb-4 text-center">Rate your liked recipes</h2>
+      <div className="space-y-6">
+        {likedRecipes.map((recipe, index) => (
+          <div key={recipe.id} className="text-center">
+            <img
+              src={recipe.img}
+              alt={recipe.name}
+              className="mx-auto mb-2 w-40 h-40 object-cover rounded"
+            />
+            <p className="font-semibold mb-1">{recipe.name}</p>
+            <select
+              className="border p-1"
+              value={ratings[index]}
+              onChange={(e) => handleChange(index, e.target.value)}
+            >
+              <option value={0}>Select rating</option>
+              {[1, 2, 3, 4, 5].map((num) => (
+                <option key={num} value={num}>{num}</option>
+              ))}
+            </select>
+          </div>
+        ))}
+      </div>
+      <div className="text-center mt-6">
+        <Link to="/" className="bg-pink-500 text-white px-4 py-2 rounded">Finish</Link>
+      </div>
+    </div>
+  );
+}
+

--- a/src/Swipe.jsx
+++ b/src/Swipe.jsx
@@ -7,18 +7,27 @@ export default function Swipe() {
   const navigate = useNavigate();
   const { recipes } = useContext(RecipeContext);
   const [sessionRecipes, setSessionRecipes] = useState(recipes);
+  const [liked, setLiked] = useState([]);
 
   useEffect(() => {
     setSessionRecipes(recipes);
+    setLiked([]);
   }, [recipes]);
 
   const handleSwipe = (dir, recipe) => {
+    const remaining = sessionRecipes.filter((r) => r.id !== recipe.id);
     if (dir === 'right') {
-      navigate('/match', { state: { recipe } });
+      const newLiked = [...liked, recipe];
+      setLiked(newLiked);
+      if (remaining.length === 0) {
+        navigate('/rate', { state: { likedRecipes: newLiked } });
+      }
+    } else if (dir === 'left') {
+      if (remaining.length === 0) {
+        navigate('/rate', { state: { likedRecipes: liked } });
+      }
     }
-    if (dir === 'left' || dir === 'right') {
-      setSessionRecipes((prev) => prev.filter((r) => r.id !== recipe.id));
-    }
+    setSessionRecipes(remaining);
   };
 
   return (


### PR DESCRIPTION
## Summary
- add new `RateLikes` component to rate liked recipes
- update `App` routes to include `/rate`
- revise `Swipe` logic to store likes and navigate to rating page after finishing recipes

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857b70efc908328ace43c1202f0f667