### PR TITLE
Add drag-and-drop ranking for liked recipes

### DIFF
--- a/src/RateLikes.jsx
+++ b/src/RateLikes.jsx
@@ -1,13 +1,29 @@
 import { useLocation, Link } from 'react-router-dom';
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 
 export default function RateLikes() {
   const location = useLocation();
   const likedRecipes = location.state?.likedRecipes || [];
-  const [ratings, setRatings] = useState(likedRecipes.map(() => 0));
+  const [ordered, setOrdered] = useState(likedRecipes);
+  const dragItem = useRef(null);
+  const dragOverItem = useRef(null);
 
-  const handleChange = (index, value) => {
-    setRatings((prev) => prev.map((r, i) => (i === index ? Number(value) : r)));
+  const handleDragStart = (index) => {
+    dragItem.current = index;
+  };
+
+  const handleDragEnter = (index) => {
+    dragOverItem.current = index;
+  };
+
+  const handleDragEnd = () => {
+    const items = [...ordered];
+    const dragged = items[dragItem.current];
+    items.splice(dragItem.current, 1);
+    items.splice(dragOverItem.current, 0, dragged);
+    dragItem.current = null;
+    dragOverItem.current = null;
+    setOrdered(items);
   };
 
   if (likedRecipes.length === 0) {
@@ -21,31 +37,37 @@ export default function RateLikes() {
 
   return (
     <div className="p-4">
-      <h2 className="text-xl font-bold mb-4 text-center">Rate your liked recipes</h2>
-      <div className="space-y-6">
-        {likedRecipes.map((recipe, index) => (
-          <div key={recipe.id} className="text-center">
+      <h2 className="text-xl font-bold mb-4 text-center">
+        Rank your liked recipes by dragging them
+      </h2>
+      <div className="flex justify-center space-x-4 overflow-x-auto">
+        {ordered.map((recipe, index) => (
+          <div
+            key={recipe.id}
+            draggable
+            onDragStart={() => handleDragStart(index)}
+            onDragEnter={() => handleDragEnter(index)}
+            onDragEnd={handleDragEnd}
+            onDragOver={(e) => e.preventDefault()}
+            className="text-center cursor-move"
+          >
             <img
               src={recipe.img}
               alt={recipe.name}
-              className="mx-auto mb-2 w-40 h-40 object-cover rounded"
+              className="mb-2 w-40 h-40 object-cover rounded"
             />
             <p className="font-semibold mb-1">{recipe.name}</p>
-            <select
-              className="border p-1"
-              value={ratings[index]}
-              onChange={(e) => handleChange(index, e.target.value)}
-            >
-              <option value={0}>Select rating</option>
-              {[1, 2, 3, 4, 5].map((num) => (
-                <option key={num} value={num}>{num}</option>
-              ))}
-            </select>
           </div>
         ))}
       </div>
       <div className="text-center mt-6">
-        <Link to="/" className="bg-pink-500 text-white px-4 py-2 rounded">Finish</Link>
+        <Link
+          to="/"
+          state={{ rankedRecipes: ordered }}
+          className="bg-pink-500 text-white px-4 py-2 rounded"
+        >
+          Finish
+        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- drag & drop to rank liked recipes at end of solo session
- center horizontal ranking list on page

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857baeb43a08328b6c2d78c12f1246e